### PR TITLE
Uncaught exception edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.0.9
+
+### Bug Fixes
+
+- Uncaught exceptions no longer close Hub app Fixes OpenBCI/OpenBCI_GUI#516 
+
 # v2.0.8
 
 ### Bug Fixes

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "openbci-electron-hub",
   "productName": "OpenBCIHub",
   "description": "OpenBCIHub",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "author": "AJ Keller <hello@pushtheworld.us>",
   "copyright": "© 2019, OpenBCI inc.",
   "homepage": "http://openbci.com",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "postinstall": "node ./node_modules/electron-builder/out/install-app-deps.js",
     "build": "gulp build",
-    "clean-install": "cd app && rm -rf node_modules && git clean -fX && npm install",
+    "clean-install-linux": "cd app && rm -rf node_modules && git clean -fX && npm install",
+    "clean-install-win": "cd app && rmdir /s node_modules && git clean -fX && npm install",
     "prerelease": "gulp build --env=production",
     "release": "build --publish never",
     "release-win32": "build --ia32 --publish never",

--- a/src/background.js
+++ b/src/background.js
@@ -138,10 +138,12 @@ let cyton = new Cyton({
 process.on("uncaughtException", function(err) {
   if (verbose) console.log("Err: ", err.message);
   dialog.showErrorBox("OpenBCIHub Fatal Error", err.message);
+  /* Leave the Hub open even after uncaught exception
   if (mb) {
     if (verbose) console.log("Closing the app");
     mb.app.quit();
   }
+  */
 });
 
 const cleanupAfterNoClients = () => {


### PR DESCRIPTION
For some reason, the CSR Dongle error catch was not working properly. Instead, it gets catched as an uncaught exception, and every uncaught exception closed the Hub.

Commented out the section that would close the Hub app, and I can still connect using a BLED112 dongle attached to my Windows Computer. Users will still get a warning popup window saying no CSR dongle is attached, then it shows up as an error in the GUI.

![failedtostartcsrdongle](https://user-images.githubusercontent.com/25914123/57963284-adca3700-78e7-11e9-9c63-d55422dc9942.PNG)
