### PR TITLE
Return firmware version in wifi connect response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.1.0
+
+### Bug Fixes
+
+- Return cyton firmware version in wifi connect response
+
 # v2.0.9
 
 ### Bug Fixes

--- a/app/package.json
+++ b/app/package.json
@@ -2,7 +2,7 @@
   "name": "openbci-electron-hub",
   "productName": "OpenBCIHub",
   "description": "OpenBCIHub",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "author": "AJ Keller <hello@pushtheworld.us>",
   "copyright": "© 2019, OpenBCI inc.",
   "homepage": "http://openbci.com",

--- a/src/background.js
+++ b/src/background.js
@@ -1022,12 +1022,22 @@ const _connectWifi = (msg, client) => {
     .then(() => {
       //TODO: Finish this connect
       if (verbose) console.log("connect success");
+      if (wifi.getBoardType() == k.OBCIBoardGanglion) {
+        return Promise.resolve('');
+      } else {
+        // Query cyton firmware version to report in connect response.
+        return wifi.write('V');
+      }
+    })
+    .then((version) => {
       // client.write(`${kTcpCmdConnect},${kTcpCodeSuccess}${kTcpStop}`);
       writeCodeToClientOfType(
         client,
         kTcpTypeConnect,
         kTcpCodeSuccess,
-        {}
+        {
+          firmware: version.trim()
+        }
       );
       // wifi.on(k.OBCIEmitterRawDataPacket, console.log);
       wifi.on("sample", sampleFunction.bind(null, client));


### PR DESCRIPTION
This parallels the implementation of the serial channel, and meets the
expectation of the GUI which expects this field regardless of communications
medium.

This is a followup to #81, which resolved OpenBCI/OpenBCI_GUI#449 for serial
communications only.